### PR TITLE
fix: injection of `frontmatter.head` fails when it does not exist

### DIFF
--- a/packages/plugin-baidu-tongji/src/node/plugin.ts
+++ b/packages/plugin-baidu-tongji/src/node/plugin.ts
@@ -8,6 +8,7 @@ export const baiduTongjiPlugin = ({ key = '' }: BaiduTongjiOptions): Plugin => {
   return {
     name: '@vuepress-plume/vuepress-plugin-baidu-tongji',
     extendsPage: (page) => {
+      page.frontmatter.head = page.frontmatter.head || [];
       page.frontmatter.head?.push([
         'script',
         {


### PR DESCRIPTION
before

![图片](https://github.com/pengzhanbo/vuepress-theme-plume/assets/44738481/98cb2c33-fe6b-4b2e-a547-6869faa9a0c5)



after

![图片](https://github.com/pengzhanbo/vuepress-theme-plume/assets/44738481/d83c5391-b1ee-4b92-bd61-fe8a30663f0f)


