### PR TITLE
feat: add config of autoFrontmatter

### DIFF
--- a/packages/theme/src/client/styles/normalize.scss
+++ b/packages/theme/src/client/styles/normalize.scss
@@ -22,6 +22,7 @@ html {
   font-size: 16px;
   line-height: 1.4;
   scroll-behavior: smooth;
+  scroll-padding-top: 80px;
 }
 
 body {

--- a/packages/theme/src/node/autoFrontmatter.ts
+++ b/packages/theme/src/node/autoFrontmatter.ts
@@ -10,7 +10,10 @@ import type {
 import type { NotesItem } from '@vuepress-plume/vuepress-plugin-notes-data'
 import { format } from 'date-fns'
 import { customAlphabet } from 'nanoid'
-import type { PlumeThemeLocaleOptions } from '../shared/index.js'
+import type {
+  PlumeThemePluginOptions,
+  PlumeThemeLocaleOptions
+} from '../shared/index.js'
 
 const nanoid = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 8)
 const require = createRequire(process.cwd())
@@ -28,6 +31,7 @@ const normalizePath = (dir: string) => {
 
 export default function autoFrontmatter(
   app: App,
+  options: PlumeThemePluginOptions,
   localeOption: PlumeThemeLocaleOptions
 ): AutoFrontmatterOptions {
   const sourceDir = app.dir.source()
@@ -86,8 +90,9 @@ export default function autoFrontmatter(
     return dirList.length > 0 ? dirList[dirList.length - 1] : ''
   }
   return {
-    include: ['**/*.md'],
-    frontmatter: [
+    include: options.frontmatter.include ?? ['**/*.{md,MD}'],
+    exclude: options.frontmatter.exclude ?? ['.vuepress/**/*', 'node_modules'],
+    frontmatter: options.frontmatter.frontmatter ?? [
       localesNotesDirs.length
         ? {
             // note 首页链接

--- a/packages/theme/src/node/plugins.ts
+++ b/packages/theme/src/node/plugins.ts
@@ -55,7 +55,7 @@ export const setupPlugins = (
           : undefined,
       } as any,
     }),
-    autoFrontmatterPlugin(autoFrontmatter(app, localeOptions)),
+    autoFrontmatterPlugin(autoFrontmatter(app, options, localeOptions)),
     blogDataPlugin({
       include: localeOptions.blog?.include,
       exclude: [

--- a/packages/theme/src/shared/options/plugins.ts
+++ b/packages/theme/src/shared/options/plugins.ts
@@ -6,6 +6,7 @@ import type { CanIUsePluginOptions } from '@vuepress-plume/vuepress-plugin-caniu
 import type { CopyCodeOptions } from '@vuepress-plume/vuepress-plugin-copy-code'
 import type { CommentPluginOptions } from 'vuepress-plugin-comment2'
 import type { MarkdownEnhanceOptions } from 'vuepress-plugin-md-enhance'
+import type { AutoFrontmatterOptions } from '@vuepress-plume/vuepress-plugin-auto-frontmatter'
 
 export interface PlumeThemePluginOptions {
   /**
@@ -49,4 +50,6 @@ export interface PlumeThemePluginOptions {
   seo?: false
 
   baiduTongji?: false | BaiduTongjiOptions
+
+  frontmatter?: AutoFrontmatterOptions
 }


### PR DESCRIPTION
## `typecho` 编辑文件导致崩溃 #17 
添加配置文件来支持配置 `autoFrontmatter` 中的 `include` `exclude` `frontmatter`

来达到可以忽略 `typecho` 产生的 `.~*.md` 文件的效果

## 在 `note` 页面内的时候，使用锚点跳转会导致错位的问题

在 `html` 上添加了一条 `css` 属性
~~~ css
html { scroll-padding-top: 80px; }
~~~