### PR TITLE
chore: use upath to replace node:path

### DIFF
--- a/plugins/plugin-auto-frontmatter/package.json
+++ b/plugins/plugin-auto-frontmatter/package.json
@@ -38,7 +38,8 @@
     "create-filter": "^1.0.1",
     "fast-glob": "^3.3.2",
     "gray-matter": "^4.0.3",
-    "json2yaml": "^1.1.0"
+    "json2yaml": "^1.1.0",
+    "upath": "2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/plugin-auto-frontmatter/src/node/readFiles.ts
+++ b/plugins/plugin-auto-frontmatter/src/node/readFiles.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import path from 'node:path'
+import path from 'upath'
 import fg from 'fast-glob'
 import type { MarkdownFile } from '../shared/index.js'
 

--- a/plugins/plugin-notes-data/package.json
+++ b/plugins/plugin-notes-data/package.json
@@ -43,6 +43,7 @@
     "@vuepress/utils": "2.0.0-rc.0",
     "chokidar": "^3.5.3",
     "create-filter": "^1.0.1",
+    "upath": "2.0.1",
     "vue": "^3.4.10"
   },
   "publishConfig": {

--- a/plugins/plugin-notes-data/src/node/prepareNotesData.ts
+++ b/plugins/plugin-notes-data/src/node/prepareNotesData.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'upath'
 import type { App } from '@vuepress/core'
 import * as chokidar from 'chokidar'
 import { createFilter } from 'create-filter'

--- a/theme/package.json
+++ b/theme/package.json
@@ -82,6 +82,7 @@
     "katex": "^0.16.9",
     "lodash.merge": "^4.6.2",
     "nanoid": "^5.0.4",
+    "upath": "2.0.1",
     "vue": "^3.4.10",
     "vue-router": "4.2.5",
     "vuepress-plugin-comment2": "2.0.0-rc.10",

--- a/theme/src/node/autoFrontmatter.ts
+++ b/theme/src/node/autoFrontmatter.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'upath'
 import type { App } from '@vuepress/core'
 import { resolveLocalePath } from '@vuepress/shared'
 import type {

--- a/theme/src/node/setupPages.ts
+++ b/theme/src/node/setupPages.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'upath'
 import type { App, Page } from '@vuepress/core'
 import { createPage } from '@vuepress/core'
 import type {

--- a/theme/src/node/utils.ts
+++ b/theme/src/node/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
-import path from 'node:path'
 import process from 'node:process'
+import path from 'upath'
 import { customAlphabet } from 'nanoid'
 import { getDirname } from '@vuepress/utils'
 


### PR DESCRIPTION
修复在 `windows` 平台无法正确处理路径的问题