### PR TITLE
优化功能

### DIFF
--- a/plugins/plugin-notes-data/src/node/prepareNotesData.ts
+++ b/plugins/plugin-notes-data/src/node/prepareNotesData.ts
@@ -114,11 +114,29 @@ function initSidebarByAuto(
   note: NotesItemOptions,
   pages: NotePage[],
 ): NotesSidebarItem[] {
-  pages = pages.sort((prev, next) => {
-    const pi = prev.relativePath.match(/\//g)?.length || 0
-    const ni = next.relativePath.match(/\//g)?.length || 0
-    return pi < ni ? -1 : 1
+  let tempPages = pages.map(page => {
+    return { ...page, splitPath: page.relativePath.split('/') }
   })
+
+  const maxIndex = Math.max(...tempPages.map(page => page.splitPath.length))
+  let nowIndex = 0
+
+  while (nowIndex < maxIndex) {
+    tempPages = tempPages.sort((prev, next) => {
+      const pi = prev.splitPath?.[nowIndex]?.match(/(\d+)\.(?=[^/]+$)/)?.[1]
+      const ni = next.splitPath?.[nowIndex]?.match(/(\d+)\.(?=[^/]+$)/)?.[1]
+      if (!pi || !ni) return 0
+      return parseFloat(pi) < parseFloat(ni) ? -1 : 1
+    })
+
+    nowIndex++
+  }
+
+  pages = tempPages.map(page => {
+    delete page.splitPath;
+    return page
+  })
+
   const RE_INDEX = ['index.md', 'README.md', 'readme.md']
   const result: NotesSidebarItem[] = []
   for (const page of pages) {

--- a/theme/src/client/components/PostItem.vue
+++ b/theme/src/client/components/PostItem.vue
@@ -139,12 +139,6 @@ const createTime = computed(() =>
   }
 }
 
-@media (min-width: 1200px) {
-  .post-item {
-    margin-left: 0;
-  }
-}
-
 .post-meta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
- 文章列表贴着最左侧了，但是右侧却有空间很奇怪，所以我把左边的边距去除了
- 修正了当 `note` 中 `sidebar` 设置为 `auto` 时，对于序号为 `[1,2,10]` 错误的排序成了 `[1,10,2]`