### PR TITLE
fix(theme): fix incorrect footer  layout

### DIFF
--- a/theme/src/client/components/VPFooter.vue
+++ b/theme/src/client/components/VPFooter.vue
@@ -87,6 +87,12 @@ onMounted(() => {
   .vp-footer {
     padding: 24px;
   }
+  .vp-footer.has-sidebar {
+    margin-left: calc(
+        (100% - (var(--vp-layout-max-width) - 64px)) / 2 + var(--vp-sidebar-width) -
+        32px
+      )
+  }
 }
 
 .container {


### PR DESCRIPTION
在1440px屏幕的情况下，sidebar的宽度就应该等于footer的margin-left的值，但是目前却没有处理，导致样式错乱了
![CleanShot 2024-07-16 at 15 00 36](https://github.com/user-attachments/assets/482c4c0b-c735-4494-beb7-99de055a10af)
