### PR TITLE
fix(theme): incorrect shadow when title is too long

### DIFF
--- a/theme/src/client/components/VPLink.vue
+++ b/theme/src/client/components/VPLink.vue
@@ -53,7 +53,7 @@ function linkTo(e: Event) {
 .vp-link :deep(i) {
   font-style: normal;
   font-weight: inherit;
-  line-height: normal;
   padding-right: 12px;
+  line-height: normal;
 }
 </style>

--- a/theme/src/client/components/VPLink.vue
+++ b/theme/src/client/components/VPLink.vue
@@ -54,5 +54,6 @@ function linkTo(e: Event) {
   font-style: normal;
   font-weight: inherit;
   line-height: normal;
+  padding-right: 12px;
 }
 </style>


### PR DESCRIPTION
## 问题

当导航栏中的标题过长，背面的阴影会显示错误，貌似是 `padding` 的问题，加上应有的 `padding` 即可

## 原效果

![image](https://github.com/user-attachments/assets/b25c5e3e-e727-40c3-a265-728662c9f62b)

## 现效果

![image](https://github.com/user-attachments/assets/c01635f4-9b2e-4664-9e6c-7c456d681bf3)
