### PR TITLE
fix(theme): incorrect shadow when title is too long

### DIFF
--- a/theme/src/client/components/VPMenuLink.vue
+++ b/theme/src/client/components/VPMenuLink.vue
@@ -44,6 +44,7 @@ const { page } = useData()
   font-weight: 500;
   line-height: 32px;
   color: var(--vp-c-text-1);
+  width: max-content;
   white-space: nowrap;
   border-radius: 6px;
   transition:

--- a/theme/src/client/components/VPMenuLink.vue
+++ b/theme/src/client/components/VPMenuLink.vue
@@ -39,12 +39,12 @@ const { page } = useData()
 
 .link {
   display: block;
+  width: max-content;
   padding: 0 12px;
   font-size: 14px;
   font-weight: 500;
   line-height: 32px;
   color: var(--vp-c-text-1);
-  width: max-content;
   white-space: nowrap;
   border-radius: 6px;
   transition:


### PR DESCRIPTION
## 问题

当导航栏中的标题过长并且使用的不是图标而是图片，背面的阴影会显示错误

## 原效果

![image](https://github.com/user-attachments/assets/b25c5e3e-e727-40c3-a265-728662c9f62b)

## 现效果

![image](https://github.com/user-attachments/assets/c01635f4-9b2e-4664-9e6c-7c456d681bf3)
