### PR TITLE
修复Github Action部署失败

### DIFF
--- a/cli/templates/deploy/github/.github/workflows/deploy.yml.handlebars
+++ b/cli/templates/deploy/github/.github/workflows/deploy.yml.handlebars
@@ -35,6 +35,13 @@ jobs:
           # 选择要使用的 node 版本
           node-version: 20
 
+{{#if (equal packageManager "npm")}}
+      # 安装依赖
+      # Install dependencies
+      - name: Install Dependencies
+        run: npm ci
+{{/if}}
+
 {{#if (equal packageManager "yarn")}}
       - name: Run install
         uses: borales/actions-yarn@v4


### PR DESCRIPTION
在使用npm作为包管理器的情况下，脚手架自动生成的用于Github Action Workflow的deploy.yml缺少安装npm依赖步骤，导致以下错误：
```sh
Run npm run docs:build

> alextang-docs@1.0.0 docs:build
> vuepress build docs --clean-cache --clean-temp

sh: 1: vuepress: not found
Error: Process completed with exit code 12[7](https://github.com/TheCoderAlex/docs/actions/runs/10765092249/job/29848828278#step:4:8).
```
解决方法是在安装node后，如果使用npm包管理器就使用 `npm ci` 或 `npm i` 安装依赖，即可部署成功。