### PR TITLE
fix(theme): fix grammar mistakes in site footer

### DIFF
--- a/theme/src/node/locales/en.ts
+++ b/theme/src/node/locales/en.ts
@@ -22,7 +22,7 @@ export const enLocale: PlumeThemeLocaleData = {
 
   footer: {
     message:
-      'Power by <a target="_blank" href="https://v2.vuepress.vuejs.org/">VuePress</a> & <a target="_blank" href="https://theme-plume.vuejs.press">vuepress-theme-plume</a>',
+      'Powered by <a target="_blank" href="https://v2.vuepress.vuejs.org/">VuePress</a> & <a target="_blank" href="https://theme-plume.vuejs.press">vuepress-theme-plume</a>',
   },
 }
 

--- a/theme/src/node/locales/zh.ts
+++ b/theme/src/node/locales/zh.ts
@@ -35,7 +35,7 @@ export const zhLocale: PlumeThemeLocaleData = {
 
   footer: {
     message:
-      'Power by <a target="_blank" href="https://v2.vuepress.vuejs.org/">VuePress</a> & <a target="_blank" href="https://theme-plume.vuejs.press">vuepress-theme-plume</a>',
+      'Powered by <a target="_blank" href="https://v2.vuepress.vuejs.org/">VuePress</a> & <a target="_blank" href="https://theme-plume.vuejs.press">vuepress-theme-plume</a>',
   },
 }
 


### PR DESCRIPTION
`Power by XXX` is a grammar mistake. 

This commit changed `Power by VuePress & vuepress-theme-plume` to `Powered by VuePress & vuepress-theme-plume`.

The key difference is the change from "Power" to "Powered", which makes the phrase more grammatically correct.
