### PR TITLE
fix(doc): remove an incorrect link

### DIFF
--- a/docs/notes/theme/config/plugins/代码高亮.md
+++ b/docs/notes/theme/config/plugins/代码高亮.md
@@ -142,8 +142,6 @@ interface CopyCodeOptions {
 
 实验性功能，是否启用 对 `typescript` 和 `vue` 语言的 类型提示 支持。
 
-查看 [twoslash](/guide/markdown/experiment/#twoslash) 了解更多信息。
-
 ### whitespace
 
 - 类型: `boolean | 'all' | 'boundary' | 'trailing'`


### PR DESCRIPTION
考虑到上面 `特性` 一栏里面已经有指向 `twoslash` 特性的链接，因此直接移除了这一句话