### PR TITLE
fix(docs): incorrect rust icon display in dark mode

### DIFF
--- a/docs/notes/theme/guide/代码演示/rust.md
+++ b/docs/notes/theme/guide/代码演示/rust.md
@@ -1,7 +1,7 @@
 ---
 title: Rust
 author: pengzhanbo
-icon: logos:rust
+icon: simple-icons:rust
 createTime: 2024/04/22 09:44:43
 permalink: /guide/repl/rust/
 ---


### PR DESCRIPTION
The previous rust icon was not clearly displayed in both dark and light modes
https://theme-plume.vuejs.press/guide/repl/rust/

#490