### PR TITLE
feat(theme): add support for `author` and `creation` in global copyright config, close #573

### DIFF
--- a/docs/notes/theme/guide/features/copyright.md
+++ b/docs/notes/theme/guide/features/copyright.md
@@ -91,7 +91,12 @@ export default defineUserConfig({
       license: {
         name: 'MIT', // 许可证名称
         url: 'https://your-license-url' // 许可证地址
-      }
+      },
+      author: {
+        name: 'Your Name', // 版权所有者名称
+        url: 'https://your-author-url' // 版权所有者地址
+      },
+      creation: 'reprint' // 创作方式
     }
   })
 })
@@ -116,12 +121,24 @@ export type CopyrightLicense =
  */
 type CopyrightOptions = boolean | string | CopyrightLicense | {
   /**
-   * 许可证
+   * 版权许可证
    */
-  license: CopyrightLicense | {
+  license?: CopyrightLicense | {
     name: CopyrightLicense | string
     url: string
   }
+  /**
+   * 版权所有者，未配置时，默认从 git 提交记录中获取
+   */
+  author?: {
+    name: string
+    url?: string
+  }
+  /**
+   * 创作方式，原创、翻译、转载
+   * @default 'original'
+   */
+  creation?: 'original' | 'translate' | 'reprint'
 }
 ```
 

--- a/theme/src/client/components/VPDocCopyright.vue
+++ b/theme/src/client/components/VPDocCopyright.vue
@@ -15,6 +15,7 @@ const copyright = computed<CopyrightFrontmatter | null>(() => {
   const docCopyright = (isPlainObject(frontmatter.value.copyright)
     ? frontmatter.value.copyright
     : { license: frontmatter.value.copyright === true ? '' : frontmatter.value.copyright }) as CopyrightFrontmatter
+
   if (!theme.value.copyright)
     return docCopyright
 
@@ -23,6 +24,8 @@ const copyright = computed<CopyrightFrontmatter | null>(() => {
     : { license: theme.value.copyright === true ? undefined : theme.value.copyright }) as CopyrightOptions
 
   docCopyright.license ??= themeCopyright.license
+  docCopyright.author ??= themeCopyright.author
+  docCopyright.creation ??= themeCopyright.creation
 
   return docCopyright
 })

--- a/theme/src/shared/features/copyright.ts
+++ b/theme/src/shared/features/copyright.ts
@@ -29,4 +29,12 @@ export interface CopyrightOptions {
    * @default 'CC-BY-4.0'
    */
   license?: CopyrightLicense | { name: string, url: string }
+  /**
+   * 版权所有者
+   */
+  author?: string | { name: string, url?: string }
+  /**
+   * 作品的创作方式
+   */
+  creation?: 'original' | 'translate' | 'reprint'
 }

--- a/theme/src/shared/frontmatter/post.ts
+++ b/theme/src/shared/frontmatter/post.ts
@@ -51,7 +51,6 @@ export interface CopyrightFrontmatter extends CopyrightOptions {
   /**
    * 作品的作者
    *
-   * 如果是 原创，则默认为 contributors 中的第一个，否则需要手动指定
    * @default ''
    */
   author?: string | { name: string, url?: string }


### PR DESCRIPTION
close #573