### PR TITLE
fix(theme): incorrect `sidebar` when `items` as `auto`, close #635

### DIFF
--- a/theme/src/client/composables/sidebar.ts
+++ b/theme/src/client/composables/sidebar.ts
@@ -153,7 +153,7 @@ function resolveSidebarItems(
       }
       const nextPrefix = normalizePrefix(_prefix, prefix || dir)
       if (items === 'auto') {
-        navLink.items = autoDirSidebar.value[nextPrefix]
+        navLink.items = resolveSidebarItems(autoDirSidebar.value[nextPrefix], nextPrefix)
         if (!navLink.link && autoHomeData.value[nextPrefix]) {
           navLink.link = normalizeLink(autoHomeData.value[nextPrefix])
           const nav = resolveNavLink(navLink.link)


### PR DESCRIPTION
close #635