### PR TITLE
Make blog post list responsive to screen width

### DIFF
--- a/theme/src/client/components/Blog/VPPostList.vue
+++ b/theme/src/client/components/Blog/VPPostList.vue
@@ -53,8 +53,8 @@ const {
   flex: 1 2;
   flex-direction: column;
   gap: 16px;
-  margin: 0 auto;
   max-width: 100%;
+  margin: 0 auto;
 }
 
 @media (min-width: 419px) {

--- a/theme/src/client/components/Blog/VPPostList.vue
+++ b/theme/src/client/components/Blog/VPPostList.vue
@@ -54,6 +54,7 @@ const {
   flex-direction: column;
   gap: 16px;
   margin: 0 auto;
+  max-width: 100%;
 }
 
 @media (min-width: 419px) {


### PR DESCRIPTION
博客列表页在屏幕宽度缩小时无法自适应屏幕，会出现水平方向的滚动条，这个PR修复了这个问题。