### PR TITLE
fix(plugin-md-power): avoid spellcheck in CodeEditor

### DIFF
--- a/plugins/plugin-md-power/src/client/components/CodeEditor.vue
+++ b/plugins/plugin-md-power/src/client/components/CodeEditor.vue
@@ -82,7 +82,7 @@ onUnmounted(() => {
   <div ref="editorEl" class="code-repl-editor">
     <slot />
     <!-- eslint-disable-next-line vue-a11y/form-control-has-label -->
-    <textarea ref="textAreaEl" v-model="input" class="code-repl-input" />
+    <textarea ref="textAreaEl" v-model="input" class="code-repl-input" spellcheck="false" />
   </div>
 </template>
 


### PR DESCRIPTION
Added spellcheck attribute to textarea for CodeEditor.