### PR TITLE
fix(docs): tint-plate demo

### DIFF
--- a/docs/tools/--home-hero-tint-plate.md
+++ b/docs/tools/--home-hero-tint-plate.md
@@ -1,0 +1,16 @@
+---
+pageLayout: home
+title: Vuepress Theme Plume
+config:
+  -
+    type: hero
+    full: true
+    effect: tint-plate
+    effectConfig: 210
+    hero:
+      name: Theme Plume
+      tagline: VuePress Next Theme
+      text: 一个简约易用的，功能丰富的 vuepress 文档&博客 主题
+createTime: 2025/10/30 16:14:19
+permalink: /tools/--home-hero-tint-plate/
+---


### PR DESCRIPTION
文档首页使用 lightning 后，`getEffectsByFrontmatter` 函数无法获取 tint-plate，进而导致首页背景板配置页无法使用。

通过添加无需显示的 Markdown 文件解决此问题。