### PR TITLE
fix(theme): conditionally render post navigation links on mobile devices

### DIFF
--- a/theme/src/client/components/Posts/VPPostsExtract.vue
+++ b/theme/src/client/components/Posts/VPPostsExtract.vue
@@ -96,15 +96,15 @@ const showPostsExtract = computed(() => {
             </div>
           </div>
           <div v-if="showPostsExtract" class="posts-nav" :class="{ 'no-profile': !profile }">
-            <VPLink class="nav-link" :href="tags.link" no-icon>
+            <VPLink v-if="tags.link" class="nav-link" :href="tags.link" no-icon>
               <span class="vpi-tag icon" />
               <span>{{ tags.text }}</span>
             </VPLink>
-            <VPLink class="nav-link" :href="categories.link" no-icon>
+            <VPLink v-if="categories.link" class="nav-link" :href="categories.link" no-icon>
               <span class="vpi-category icon" />
               <span>{{ categories.text }}</span>
             </VPLink>
-            <VPLink class="nav-link" :href="archives.link" no-icon>
+            <VPLink v-if="archives.link" class="nav-link" :href="archives.link" no-icon>
               <span class="vpi-archive icon" />
               <span>{{ archives.text }}</span>
             </VPLink>


### PR DESCRIPTION
若在 collections 中关闭 categories/tags/archives，移动端侧边栏仍会显示为

![](https://image.honahec.cc/20251101205214058.png)

这显然不符合逻辑，添加 v-if 字段后变为

![](https://image.honahec.cc/20251101205259400.png)