### PR TITLE
docs: fix icon documentation links

### DIFF
--- a/docs/config/markdown.md
+++ b/docs/config/markdown.md
@@ -149,7 +149,7 @@ export default defineUserConfig({
 - **默认值**: `{ provider: 'iconify' }`
 - **详情**: 图标配置
 
-  [查看 **icon** 使用说明](../../theme/guide/features/icon.md){.read-more}
+  [查看 **icon** 使用说明](../guide/features/icon.md){.read-more}
 
 ### plot
 

--- a/docs/en/config/markdown.md
+++ b/docs/en/config/markdown.md
@@ -159,7 +159,7 @@ The `include` configuration is implemented by the
 - **Default:** `{ provider: 'iconify' }`
 - **Details:** Icon configuration.
 
-  [View **icon** usage instructions](../../theme/guide/features/icon.md){.read-more}
+  [View **icon** usage instructions](../guide/features/icon.md){.read-more}
 
 ### plot
 

--- a/docs/en/guide/features/icon.md
+++ b/docs/en/guide/features/icon.md
@@ -16,7 +16,7 @@ The theme supports icons from the following sources:
 Icons are used in the same way across the following theme features:
 
 - [Navbar Icons](../../config/navbar.md#configuration)
-- [Sidebar Icons](../../guide/document.md#sidebar-icons)
+- [Sidebar Icons](../../guide/quick-start/sidebar.md#visual-enhancement-features)
 - [File Tree Icons](../../guide/markdown/file-tree.md)
 - [Code Group Title Icons](../code/code-tabs.md#group-title-icons)
 

--- a/docs/guide/features/icon.md
+++ b/docs/guide/features/icon.md
@@ -16,7 +16,7 @@ permalink: /guide/features/icon/
 在主题的以下功能中以相同的方式使用图标：
 
 - [导航栏图标](../../config/navbar.md#配置)
-- [侧边栏图标](../../guide/document.md#侧边栏图标)
+- [侧边栏图标](../quick-start/sidebar.md#视觉增强功能)
 - [文件树图标](../../guide/markdown/file-tree.md)
 - [代码分组标题图标](../code/code-tabs.md#分组标题图标)
 


### PR DESCRIPTION
- Update relative paths in markdown config documentation to point to correct guide location
- Change sidebar icons link from document.md to quick-start/sidebar.md for proper navigation structure