### PR TITLE
docs: update site URL from d.mcenahle.cn to d.mcenahle.com

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -96,8 +96,8 @@ docs:
   -
     name: mcenahle Docs
     desc: mcenahle 的文档网站。
-    logo: https://d.mcenahle.cn/images/logo.png
-    url: https://d.mcenahle.cn/
+    logo: https://d.mcenahle.com/images/logo.png
+    url: https://d.mcenahle.com/
     preview: https://mcenahle.cn/resources/docs-site-preview.jpg
 
 blog:


### PR DESCRIPTION
该网站已从 d.mcenahle.cn 迁移到 d.mcenahle.com，因此 URL 已相应更新。