### PR TITLE
docs: add plume theme demo of `dante cloud`

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -93,7 +93,13 @@ docs:
     logo: https://jm-nav.com/logo.png
     url: https://jm-nav.com/
     preview: https://jm-nav.com/preview.jpg
-  
+  -
+    name: Dante Cloud
+    desc: 国内首个支持阻塞式和响应式服务并行的微服务云原生基座
+    logo: https://www.herodotus.cn/logo.svg
+    url: https://www.herodotus.cn
+    repo: https://gitee.com/dante-compass/herodotus-documents
+    preview: https://www.herodotus.cn/plume-demo.jpg
 
 blog:
   -


### PR DESCRIPTION
Add plume theme demo of dante cloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 在演示文档中新增了"Dante Cloud"示例站点，包含完整的说明、标志、链接、仓库地址及预览图片。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->