### PR TITLE
docs: fix dead link

### DIFF
--- a/docs/config/plugins/watermark.md
+++ b/docs/config/plugins/watermark.md
@@ -1,7 +1,7 @@
 ---
 title: 水印
 createTime: 2024/06/17 15:37:18
-permalink: /config/watermark/
+permalink: /config/plugins/watermark/
 ---
 
 ## 概述


### PR DESCRIPTION
从”/config/watermark/“改为“/config/plugins/watermark/”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新水印插件配置文档的访问路径，确保链接指向新的插件配置页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->