### PR TITLE
feat(theme): add `doc-content-after` slots

### DIFF
--- a/docs/en/guide/custom/slots.md
+++ b/docs/en/guide/custom/slots.md
@@ -103,6 +103,7 @@ You can preview <https://plume-layout-slots.netlify.app> to see the positions of
   - `doc-top`
   - `doc-bottom`
   - `doc-content-before`
+  - `doc-content-after`
   - `doc-footer-before`
   - `doc-before`
   - `doc-after`
@@ -112,8 +113,6 @@ You can preview <https://plume-layout-slots.netlify.app> to see the positions of
   - `doc-meta-bottom`
   - `doc-meta-before`
   - `doc-meta-after`
-  - `doc-content-before`
-  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/docs/en/guide/custom/slots.md
+++ b/docs/en/guide/custom/slots.md
@@ -112,6 +112,8 @@ You can preview <https://plume-layout-slots.netlify.app> to see the positions of
   - `doc-meta-bottom`
   - `doc-meta-before`
   - `doc-meta-after`
+  - `doc-content-before`
+  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/docs/guide/custom/slots.md
+++ b/docs/guide/custom/slots.md
@@ -110,6 +110,8 @@ export default defineClientConfig({
   - `doc-meta-bottom`
   - `doc-meta-before`
   - `doc-meta-after`
+  - `doc-content-before`
+  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/docs/guide/custom/slots.md
+++ b/docs/guide/custom/slots.md
@@ -101,6 +101,7 @@ export default defineClientConfig({
   - `doc-top`
   - `doc-bottom`
   - `doc-content-before`
+  - `doc-content-after`
   - `doc-footer-before`
   - `doc-before`
   - `doc-after`
@@ -110,8 +111,6 @@ export default defineClientConfig({
   - `doc-meta-bottom`
   - `doc-meta-before`
   - `doc-meta-after`
-  - `doc-content-before`
-  - `doc-content-after`
   - `sidebar-nav-before`
   - `sidebar-nav-after`
   - `aside-top`

--- a/examples/layout-slots/docs/.vuepress/client.ts
+++ b/examples/layout-slots/docs/.vuepress/client.ts
@@ -36,6 +36,8 @@ export default defineClientConfig({
       'doc-meta-after': () => h(SlotDemo, { name: 'doc-meta-after', h: 24 }),
       'doc-meta-top': () => h(SlotDemo, { name: 'doc-meta-top' }),
       'doc-meta-bottom': () => h(SlotDemo, { name: 'doc-meta-bottom' }),
+      'doc-content-before': () => h(SlotDemo, { name: 'doc-content-before', h: 60, mt: 16 }),
+      'doc-content-after': () => h(SlotDemo, { name: 'doc-content-after', h: 60, mt: 16 }),
 
       'sidebar-nav-before': () => h(SlotDemo, { name: 'sidebar-nav-before' }),
       'sidebar-nav-after': () => h(SlotDemo, { name: 'sidebar-nav-after' }),

--- a/theme/src/client/components/VPContent.vue
+++ b/theme/src/client/components/VPContent.vue
@@ -51,7 +51,7 @@ watch(
     <VPPosts
       v-if="isPostsLayout || frontmatter.pageLayout === 'posts'"
       :home-posts="frontmatter.pageLayout === 'posts'"
-      :collection="frontmatter.collection as string"
+      :collection="`${frontmatter.collection}`"
     >
       <template #posts-top>
         <slot name="posts-top" />
@@ -168,6 +168,9 @@ watch(
       </template>
       <template #doc-content-before>
         <slot name="doc-content-before" />
+      </template>
+      <template #doc-content-after>
+        <slot name="doc-content-after" />
       </template>
       <template #doc-footer-before>
         <slot name="doc-footer-before" />

--- a/theme/src/client/components/VPContent.vue
+++ b/theme/src/client/components/VPContent.vue
@@ -51,7 +51,7 @@ watch(
     <VPPosts
       v-if="isPostsLayout || frontmatter.pageLayout === 'posts'"
       :home-posts="frontmatter.pageLayout === 'posts'"
-      :collection="`${frontmatter.collection}`"
+      :collection="`${frontmatter.collection ?? ''}`"
     >
       <template #posts-top>
         <slot name="posts-top" />

--- a/theme/src/client/components/VPDoc.vue
+++ b/theme/src/client/components/VPDoc.vue
@@ -148,6 +148,8 @@ watch(
 
                   <Content />
 
+                  <slot name="doc-content-after" />
+
                   <DocGitContributors v-if="contributorsMode === 'block'" />
                   <DocGitChangelog />
                   <VPDocCopyright />

--- a/theme/src/client/layouts/Layout.vue
+++ b/theme/src/client/layouts/Layout.vue
@@ -116,6 +116,9 @@ registerWatchers()
           <template #doc-content-before>
             <slot name="doc-content-before" />
           </template>
+          <template #doc-content-after>
+            <slot name="doc-content-after" />
+          </template>
           <template #doc-footer-before>
             <slot name="doc-footer-before" />
           </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `doc-content-after` 插槽，支持在文档内容后插入自定义内容。
  * 补充文档内容前后插槽的配置示例，便于预览效果。

* **文档**
  * 更新中文和英文文档中的布局插槽列表。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->