### PR TITLE
fix(theme): use the parent directory name as the auto frontmatter title

### DIFF
--- a/theme/src/node/autoFrontmatter/helper.ts
+++ b/theme/src/node/autoFrontmatter/helper.ts
@@ -24,7 +24,7 @@ export function getFileCreateTime(filepath: string): string {
 
 export function getCurrentName(filepath: string): string {
   if (isReadme(filepath))
-    return normalizeTitle(path.dirname(filepath).slice(-1).split('/').pop() || 'Home')
+    return normalizeTitle(path.basename(path.dirname(filepath)) || 'Home')
 
   return normalizeTitle(path.basename(filepath, '.md'))
 }


### PR DESCRIPTION
Auto frontmatter uses the last letter of a directory as the title. `notes/guide/README.md` ends up with `title: e` written into it, `notes/123.docs/index.md` with `title: s`. It writes back to the source file. So that lands in someone's markdown, not just the build output.

Nothing in the repo trips over it. It's skipped where a `title:` alredy exists, and every README under `docs/` has one written by hand. No test in the diff either - `theme/` hasnt got a `__test__` dir and I didn't fancy starting one for a one-line fix.

Checked against `vuepress-theme-plume@1.0.0-rc.205` from npm rather than the working tree: a docs tree with one `notes/guide/README.md` in it, built, then read back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 README 文件名称的识别逻辑，现可更准确地使用其所在目录名称。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->