### PR TITLE
refactor(plugin-md-power): migrate `image-size` to `tiny-image-size`

### DIFF
--- a/plugins/plugin-md-power/package.json
+++ b/plugins/plugin-md-power/package.json
@@ -98,7 +98,6 @@
     "@vueuse/core": "catalog:prod",
     "chokidar": "catalog:prod",
     "gray-matter": "catalog:prod",
-    "image-size": "catalog:prod",
     "local-pkg": "catalog:prod",
     "lru-cache": "catalog:prod",
     "markdown-it-cjk-friendly": "catalog:prod",
@@ -108,6 +107,7 @@
     "qrcode": "catalog:prod",
     "rolldown": "catalog:prod",
     "shiki": "catalog:prod",
+    "tiny-image-size": "catalog:prod",
     "tm-grammars": "catalog:prod",
     "tm-themes": "catalog:prod",
     "vue": "catalog:prod"

--- a/plugins/plugin-md-power/src/node/enhance/imageSize.ts
+++ b/plugins/plugin-md-power/src/node/enhance/imageSize.ts
@@ -6,8 +6,8 @@ import http from 'node:https'
 import { URL } from 'node:url'
 import { attempt, isBoolean, objectEntries, withTimeout } from '@pengzhanbo/utils'
 import { isLinkHttp } from '@vuepress/helper'
-import imageSize from 'image-size'
 import pMap from 'p-map'
+import { tinyImageSize } from 'tiny-image-size'
 import { fs, logger, path } from 'vuepress/utils'
 import { resolveAttrs } from '../utils/resolveAttrs.js'
 
@@ -60,6 +60,8 @@ const BADGE_LIST = [
   'https://badgen.net',
   'https://forthebadge.com',
   'https://vercel.com/button',
+  'https://npmx.dev',
+  'https://codecov.io',
 ]
 
 /**
@@ -252,14 +254,16 @@ export async function getImageOriginalSize(
   const isRemote = isLinkHttp(image)
   // remote image
   if (isRemote && includeRemote && !BADGE_LIST.some(badge => image.startsWith(badge))) {
-    const { width, height } = await fetchRemoteImageSize(image.startsWith('//') ? `https:${image}` : image)
+    const { width, height } = await fetchRemoteImageSize(
+      image.startsWith('//') ? `https:${image}` : image,
+    )
     if (width && height)
       return { width, height }
   }
   if (!isRemote) {
-    const [, data] = attempt(() => imageSize(fs.readFileSync(image)))
+    const [, data] = attempt(() => tinyImageSize(fs.readFileSync(image)))
     if (data?.width && data?.height)
-      return { width: data.width, height: data.height }
+      return data
   }
   return null
 }
@@ -303,7 +307,7 @@ async function fetchRemoteImageSize(src: string): Promise<ImgSize> {
         const chunks: any[] = []
         for await (const chunk of stream) {
           chunks.push(chunk)
-          const [, data] = attempt(imageSize, Buffer.concat(chunks))
+          const [, data] = attempt(tinyImageSize, Buffer.concat(chunks))
           if (data && data.width && data.height)
             return resolve(data)
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,9 +239,6 @@ catalogs:
     hash-wasm:
       specifier: ^4.12.0
       version: 4.12.0
-    image-size:
-      specifier: ^2.0.2
-      version: 2.0.2
     js-tokens:
       specifier: ^10.0.0
       version: 10.0.0
@@ -311,6 +308,9 @@ catalogs:
     sort-package-json:
       specifier: ^4.0.0
       version: 4.0.0
+    tiny-image-size:
+      specifier: ^1.0.0
+      version: 1.0.0
     tm-grammars:
       specifier: ^1.32.3
       version: 1.32.3
@@ -720,9 +720,6 @@ importers:
       gray-matter:
         specifier: catalog:prod
         version: 4.0.3
-      image-size:
-        specifier: catalog:prod
-        version: 2.0.2
       less:
         specifier: catalog:dev
         version: 4.8.1(supports-color@10.2.2)
@@ -768,6 +765,9 @@ importers:
       stylus:
         specifier: catalog:dev
         version: 0.64.0(supports-color@10.2.2)
+      tiny-image-size:
+        specifier: catalog:prod
+        version: 1.0.0
       tm-grammars:
         specifier: catalog:prod
         version: 1.32.3
@@ -5158,11 +5158,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  image-size@2.0.2:
-    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
@@ -7053,6 +7048,9 @@ packages:
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
+
+  tiny-image-size@1.0.0:
+    resolution: {integrity: sha512-0A3CAfJrw+Cp6mxJgumyvqXx19t6WvvaZke2qmJATnHjoHety9UBZPTeAVd5jcyO7wpSIUov3VGn1NTHjH6cdg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -12271,8 +12269,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  image-size@2.0.2: {}
-
   immediate@3.0.6: {}
 
   immutable@5.1.5: {}
@@ -14458,6 +14454,8 @@ snapshots:
   time-span@5.1.0:
     dependencies:
       convert-hrtime: 5.0.0
+
+  tiny-image-size@1.0.0: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,7 +149,6 @@ catalogs:
     focus-trap: ^8.2.2
     gray-matter: ^4.0.3
     hash-wasm: ^4.12.0
-    image-size: ^2.0.2
     js-tokens: ^10.0.0
     js-yaml: ^5.2.3
     katex: ^0.18.4
@@ -173,6 +172,7 @@ catalogs:
     rolldown: ^1.2.3
     shiki: ^4.4.3
     sort-package-json: ^4.0.0
+    tiny-image-size: ^1.0.0
     tm-grammars: ^1.32.3
     tm-themes: ^1.12.3
     vue: ^3.5.41


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 优化 Markdown 图片尺寸解析，提升本地图片和远程图片的处理兼容性。
  * 新增对部分徽章图片来源的排除处理，减少不必要的尺寸解析。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->