### PR TITLE
fix(plugin-md-power): fix`tabs` container not rendering correctly， close #965

### DIFF
--- a/plugins/plugin-md-power/src/node/container/tabs.ts
+++ b/plugins/plugin-md-power/src/node/container/tabs.ts
@@ -24,7 +24,7 @@ export const tabs: PluginSimple = (md) => {
   tab(md, {
     name: 'tabs',
 
-    openRender: ({ active, data }, tokens, index, _, env) => {
+    openRenderer: ({ active, data }, tokens, index, _, env) => {
       const { meta } = tokens[index]
       const titles = data.map(({ title }) => md.renderInline(title, cleanMarkdownEnv(env)))
       const tabsData = data.map((item, dataIndex) => {
@@ -39,11 +39,11 @@ ${titles.map((title, titleIndex) =>
 ).join('')}`
     },
 
-    closeRender: () => `</Tabs>`,
+    closeRenderer: () => `</Tabs>`,
 
-    tabOpenRender: ({ index }) =>
+    tabOpenRenderer: ({ index }) =>
       `<template #tab${index}="{ value, isActive }">`,
 
-    tabCloseRender: () => `</template>`,
+    tabCloseRenderer: () => `</template>`,
   })
 }


### PR DESCRIPTION
close #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * `tabs` 插件的渲染器配置项名称已更新：
    * `openRender` → `openRenderer`
    * `closeRender` → `closeRenderer`
    * `tabOpenRender` → `tabOpenRenderer`
    * `tabCloseRender` → `tabCloseRenderer`
  * 回调函数签名及其返回的标记内容保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->