### PR TITLE
docs: fix dead links and the obsidian plugin key

### DIFF
--- a/docs/en/guide/markdown/v-obsidian.md
+++ b/docs/en/guide/markdown/v-obsidian.md
@@ -28,7 +28,7 @@ Obsidian compatibility features are all enabled by default. You can selectively 
 export default defineUserConfig({
   theme: plumeTheme({
     plugins: {
-      mdPower: {
+      markdownPower: {
         obsidian: {
           wikiLink: true,    // Wiki Links
           embedLink: true,  // Embeds
@@ -168,7 +168,7 @@ In `docs/guide/markdown/obsidian.md`:
 
 [[file-tree#Configuration]]
 
-[Obsidian Official - **Wiki Links**](https://obsidian.md/en/help/links){.readmore}
+[Obsidian Official - **Wiki Links**](https://obsidian.md/help/links){.readmore}
 
 ## Embeds
 
@@ -282,8 +282,8 @@ Content fragments under a specified heading can be embedded using `#heading`:
 ![[my-note#Heading One#Subheading]]
 ```
 
-[Obsidian Official - **Insert Files**](https://obsidian.md/en/help/embeds){.readmore}
-[Obsidian Official - **File Formats**](https://obsidian.md/en/help/file-formats){.readmore}
+[Obsidian Official - **Insert Files**](https://obsidian.md/help/embeds){.readmore}
+[Obsidian Official - **File Formats**](https://obsidian.md/help/file-formats){.readmore}
 
 ## Callout
 
@@ -400,7 +400,7 @@ The `details` type renders as an HTML `<details>` element, supporting collapse/e
 >
 > This is hidden content.
 
-[Obsidian Official - **Callout**](https://obsidian.md/en/help/callouts){.readmore}
+[Obsidian Official - **Callout**](https://obsidian.md/help/callouts){.readmore}
 
 ## Comments
 
@@ -465,7 +465,7 @@ This is a block comment.
 
 It can span multiple lines.
 
-[Obsidian Official - **Comments**](https://obsidian.md/en/help/syntax#%E6%B3%A8%E9%87%8B){.readmore}
+[Obsidian Official - **Comments**](https://obsidian.md/help/syntax#Comments){.readmore}
 
 ## Notes
 

--- a/docs/guide/markdown/v-obsidian.md
+++ b/docs/guide/markdown/v-obsidian.md
@@ -27,7 +27,7 @@ Obsidian 兼容功能默认全部启用，你可以通过配置选择性地启�
 export default defineUserConfig({
   theme: plumeTheme({
     plugins: {
-      mdPower: {
+      markdownPower: {
         obsidian: {
           wikiLink: true,    // Wiki 链接
           embedLink: true,  // 嵌入内容

--- a/docs/guide/quick-start/intro.md
+++ b/docs/guide/quick-start/intro.md
@@ -37,7 +37,7 @@ VuePress 是一个[静态站点生成器](https://en.wikipedia.org/wiki/Static_s
 - **多样化布局**：支持完全自定义的==首页==，可选==文章列表==、==文档==模式
 - **内容增强**：内置==全文搜索==、==文章评论==、==内容加密==、==文章水印==等实用功能
 - **代码展示**：支持代码块==分组==、==折叠==、==聚焦==、==行高亮==、==差异对比==，可嵌入 CodePen、JSFiddle、CodeSandbox 等平台的==代码演示==
-- **图标系统**：集成 [iconify](https://icon-sets.iconify.d/) **200,000+** ==图标==，可选配 `iconfont` / `fontawesome` 图标库
+- **图标系统**：集成 [iconify](https://icon-sets.iconify.design/) **200,000+** ==图标==，可选配 `iconfont` / `fontawesome` 图标库
 - **媒体嵌入**：支持==PDF 嵌入==、==Bilibili/Youtube/本地视频==嵌入
 - **图表渲染**：集成 chart.js、Echarts、Mermaid、Flowchart、Markmap、PlantUML 等多种==图表引擎==
 - **布局容器**：灵活的 Markdown 容器语法，提供==提示容器==、==文件树==、==代码树==、==卡片容器==、==瀑布流容器==等


### PR DESCRIPTION
Five "Obsidian Official" links on the English Obsidian page return 404, and its config sample uses a plugin key the theme doesn't read.

The Chinese page keeps its `https://obsidian.md/zh/help/*` links - all five still return 200. Obsidian dropped only `/en/`, while `/zh/` and bare `/help/` remain.

> for s in links embeds file-formats callouts syntax; do
>   curl -sSI -o /dev/null -w '%{http_code}\n' https://obsidian.md/en/help/$s
> done
> 404
> 404
> 404
> 404
> 404

Dropping `/en/` returns 200 for all five. These are the only `obsidian.md/en/help` links in the repo.

The sample nests `obsidian`, `pdf` and `artPlayer` under `plugins.mdPower`, but `theme/src/node/plugins/markdown.ts` reads `pluginOptions.markdownPower` and nothing reads `plugins.mdPower`. Copying it sets none of those options. I've kept the example in the existing `plugins` namespace rather than moving it to the recommended top-level `markdown:` entry - it's the smaller edit.

Click any of five English Obsidian rederence links and you land on a 404 page. Copy the config and your setings do nothing, with no reason to suspect the key. The broken iconify link sits on the getting started intro page, close to the first thing a new reader clicks.

That iconify domain is cut short at `iconify.d`. The matching English feature bullet alredy uses `icon-sets.iconify.design`, which returns 200.

I couldn't browser-check the new `#Comments` anchor because the page HTML is a small JavaScript shell with no headings. I checked the published source instead: `en/Editing and formatting/Basic formatting syntax.md` has `## Comments`, and Obsidian Publish keeps raw heading text, including capitals and spaces, in anchors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新 Obsidian 配置示例中的插件配置键名。
  * 修正 Wiki Links、嵌入、Callout 和 Comments 的官方文档链接。
  * 修正快速入门指南中的 Iconify 链接域名。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->